### PR TITLE
fix: add missing methods to purge style cache

### DIFF
--- a/packages/alloy-compiler/lib/compilers/alloy.js
+++ b/packages/alloy-compiler/lib/compilers/alloy.js
@@ -97,6 +97,10 @@ class AlloyCompiler {
 		const compiler = this.factory.createCompiler('style');
 		return compiler.compile(options);
 	}
+
+	purgeStyleCache(componentPath) {
+		this.factory.createCompiler('style').purgeStyleCache(componentPath);
+	}
 }
 
 module.exports = AlloyCompiler;

--- a/packages/alloy-compiler/lib/compilers/base.js
+++ b/packages/alloy-compiler/lib/compilers/base.js
@@ -140,6 +140,12 @@ class BaseCompiler {
 		return null;
 	}
 
+	/**
+	 * Loads the styles object for the given component.
+	 *
+	 * @param {object} meta Component metadata
+	 * @return {object} Object that contains styles and file dependencies
+	 */
 	loadStyles(meta) {
 		const {
 			cacheIdentifier,
@@ -157,7 +163,7 @@ class BaseCompiler {
 		const { config: compileConfig, theme } = this;
 		const buildPlatform = compileConfig.alloyConfig.platform;
 		let styles = styler.globalStyle || [];
-		const files = [ path.join(this.appDir, 'styles', 'app.tss') ];
+		const files = [];
 		let message = '';
 
 		if (componentFiles.STYLE) {
@@ -271,6 +277,20 @@ class BaseCompiler {
 		}
 
 		return {};
+	}
+
+	/**
+	 * Purges the style cache for a given component.
+	 *
+	 * @param {string} componentPath Path of component to purge style cache for
+	 */
+	purgeStyleCache(componentPath) {
+		try {
+			const meta = this.resolveComponentMeta(componentPath);
+			styleCache.delete(meta.cacheIdentifier);
+		} catch (e) {
+			// silently ignore possible component lookup errors
+		}
 	}
 }
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-28054

The style cache needs to be cleared for components when its `.tss` file changes. The interface for this was missing and is needed by the alloy-loader for Webpack to properly clear the cache on watch builds.