### PR TITLE
fix: use default export for es6 base controller

### DIFF
--- a/packages/alloy-compiler/template/component.es6.js
+++ b/packages/alloy-compiler/template/component.es6.js
@@ -16,7 +16,11 @@ function __processArg(obj, key) {
 
 export default function Controller() {
 	<%= Widget %>
-	require('/alloy/controllers/' + <%= parentController %>).apply(this, Array.prototype.slice.call(arguments));
+	let BaseController = require('/alloy/controllers/' + <%= parentController %>);
+	if (BaseController.__esModule && BaseController.default) {
+		BaseController = BaseController.default;
+	}
+	BaseController.apply(this, Array.prototype.slice.call(arguments));
 	this.__controllerPath = '<%= controllerPath %>';
 	this.args = arguments[0] || {};
 

--- a/packages/alloy-compiler/test/unit/webpack.spec.js
+++ b/packages/alloy-compiler/test/unit/webpack.spec.js
@@ -35,7 +35,11 @@ describe('webpack compiler', () => {
 
 		export default function Controller() {
 
-			require('/alloy/controllers/' + 'BaseController').apply(this, Array.prototype.slice.call(arguments));
+			let BaseController = require('/alloy/controllers/' + 'BaseController');
+			if (BaseController.__esModule && BaseController.default) {
+				BaseController = BaseController.default;
+			}
+			BaseController.apply(this, Array.prototype.slice.call(arguments));
 			this.__controllerPath = 'index';
 			this.args = arguments[0] || {};
 


### PR DESCRIPTION
Make sure to use the `default` export from ES module base controllers.