### PR TITLE
chore: sync with alloy 1.15.2

### DIFF
--- a/packages/alloy-compiler/builtins/animation.js
+++ b/packages/alloy-compiler/builtins/animation.js
@@ -20,8 +20,8 @@ exports.HORIZONTAL = 'horizontal';
  */
 exports.VERTICAL = 'vertical';
 
-const create3DMatrix = Ti.version >= '8.0.0' ? Ti.UI.createMatrix3D : Ti.UI.create3DMatrix;
-const create2DMatrix = Ti.version >= '8.0.0' ? Ti.UI.createMatrix2D : Ti.UI.create2DMatrix;
+const create3DMatrix = Ti.UI.createMatrix3D ? Ti.UI.createMatrix3D : Ti.UI.create3DMatrix;
+const create2DMatrix = Ti.UI.createMatrix2D ? Ti.UI.createMatrix2D : Ti.UI.create2DMatrix;
 
 /**
  * @method flip

--- a/packages/alloy-compiler/lib/compilerUtils.js
+++ b/packages/alloy-compiler/lib/compilerUtils.js
@@ -231,7 +231,7 @@ exports.getParserArgs = function (node, state, opts) {
 				}
 			}
 
-			if (/(^|\+)\s*(?:(?:Ti|Titanium|Alloy.Globals|Alloy.CFG|\$.args)\.|L\(.+\)\s*$)/.test(theValue)) {
+			if (/(^|\+)\s*(?:(?:Ti|Titanium|Alloy.Globals|Alloy.CFG|\$.args)\.|L\(.+\)\s*$|WPATH\()/.test(theValue)) {
 				var match = theValue.match(/^\s*L\([^'"]+\)\s*$/);
 				if (match !== null) {
 					theValue = theValue.replace(/\(/g, '("').replace(/\)/g, '")');

--- a/packages/alloy-compiler/lib/parsers/Alloy.Require.js
+++ b/packages/alloy-compiler/lib/parsers/Alloy.Require.js
@@ -134,15 +134,21 @@ function parse(node, state, args) {
 		type === 'widget' ? 'Alloy.Widget' : 'Alloy.Require',
 		args.createArgs,
 		state
-	) + ');\n';
+	) + ')';
+	let parent = {
+		symbol: args.symbol + '.getViewEx({recurse:true})'
+	};
 	if (args.parent.symbol && !state.templateObject && !state.androidMenu) {
-		code += args.symbol + '.setParent(' + args.parent.symbol + ');\n';
+		code += ';\n' + args.symbol + '.setParent(' + args.parent.symbol + ');\n';
+	} else if (type === 'widget' && (node.parentNode && node.parentNode.nodeName === 'Alloy')) {
+		code += '.getViewEx({recurse:true});\n';
+		parent = { symbol: args.symbol };
+	} else {
+		code += ';\n';
 	}
 
 	return {
-		parent: {
-			symbol: args.symbol + '.getViewEx({recurse:true})'
-		},
+		parent: parent,
 		controller: args.symbol,
 		styles: state.styles,
 		code: code

--- a/packages/alloy-compiler/lib/parsers/Ti.UI.ListSection.js
+++ b/packages/alloy-compiler/lib/parsers/Ti.UI.ListSection.js
@@ -163,7 +163,7 @@ function parse(node, state, args) {
 			items: itemCode,
 			post: 'opts.animation ? '
 				+ sps + '.setItems(' + itemsVar + ', opts.animation) : '
-				+ sps + '.setItems(' + itemsVar + ');'
+				+ sps + '.items = ' + itemsVar + ';'
 		});
 	}
 

--- a/packages/alloy-compiler/lib/parsers/Ti.UI.Tab.js
+++ b/packages/alloy-compiler/lib/parsers/Ti.UI.Tab.js
@@ -25,6 +25,7 @@ function parse(node, state) {
 	if (theNode) {
 		code += CU.generateNodeExtended(child, state, {
 			parent: {},
+			insideContainer: true,
 			post: function (node, state) {
 				windowSymbol = state.parent.symbol;
 			}


### PR DESCRIPTION
This pulls in the most recent changes from Alloy 1.15.2 that affected the compiler.

PRs included:

https://github.com/appcelerator/alloy/pull/948
https://github.com/appcelerator/alloy/pull/949
https://github.com/appcelerator/alloy/pull/960
https://github.com/appcelerator/alloy/pull/966