### PR TITLE
fix(compiler): allow tabgroup as a child of navigationwindow

### DIFF
--- a/packages/alloy-compiler/lib/parsers/Ti.UI.NavigationWindow.js
+++ b/packages/alloy-compiler/lib/parsers/Ti.UI.NavigationWindow.js
@@ -5,6 +5,7 @@ var styler = require('../styler'),
 
 const MIN_VERSION_FOR_IOS = '3.1.3';
 const MIN_VERSION = '8.0.0';
+const MIN_ANDROID_TABGROUP_CHILD = '8.3.0';
 
 exports.parse = function (node, state) {
 	return require('./base').parse(node, state, parse);
@@ -12,6 +13,7 @@ exports.parse = function (node, state) {
 
 function parse(node, state) {
 	const tiappSdkVersion = tiapp.getSdkVersion();
+	const platform =  CU.getCompilerConfig().alloyConfig.platform;
 	if (tiapp.version.lt(tiappSdkVersion, MIN_VERSION_FOR_IOS)) {
 		U.die(`Ti.UI.iOS.NavigationWindow (line ${node.lineNumber}) requires Titanium ${MIN_VERSION_FOR_IOS}+`);
 	}
@@ -21,18 +23,22 @@ function parse(node, state) {
 	}
 
 	var children = U.XML.getElementsFromNodes(node.childNodes),
-		err = [ 'NavigationWindow must have only one child element, which must be a Window' ],
+		err = [ 'NavigationWindow must have only one child element, which must be a Window or TabGroup' ],
 		code = '';
 
-	// NavigationWindow must have 1 window as a child
+	// NavigationWindow must have 1 window or tabgroup as a child
 	if (children.length !== 1) {
 		U.die(err);
 	}
 
 	var child = children[0],
 		childArgs = CU.getParserArgs(child),
-		theNode = CU.validateNodeName(child, 'Ti.UI.Window'),
+		theNode = CU.validateNodeName(child, [ 'Ti.UI.Window', 'Ti.UI.TabGroup' ]),
 		windowSymbol;
+
+	if (platform === 'android' && theNode === 'Ti.UI.TabGroup' && tiapp.version.lt(tiappSdkVersion, MIN_ANDROID_TABGROUP_CHILD)) {
+		U.die(`TabGroup can only be a child of a NavigationWindow on Android from SDK ${MIN_ANDROID_TABGROUP_CHILD} onwards. Current SDK is ${tiappSdkVersion}`);
+	}
 
 	// generate the code for the Window first
 	if (theNode) {


### PR DESCRIPTION
Closes [ALOY-1744](https://jira.appcelerator.org/browse/ALOY-1744)

Mirrors appcelerator/alloy/pull/1067